### PR TITLE
disable style/documentation check

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -578,6 +578,9 @@ Style/CommentAnnotation:
 Style/DateTime:
   Enabled: false
 
+Style/Documentation:
+  Enabled: false
+
 # Warn on empty else statements
 # empty - warn only on empty `else`
 # nil - warn on `else` with nil in it


### PR DESCRIPTION
https://rubocop.readthedocs.io/en/latest/cops_style/#styledocumentation is trying to push for making comments for all top-level classes. discussed with jamie that this isn't something we as an organization want [or i as an individual, to be clear heh].