### PR TITLE
disable struct inheritance rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -965,6 +965,9 @@ Style/StringMethods:
   PreferredMethods:
     intern: to_sym
 
+Style/StructInheritance:
+  Enabled: false
+
 Style/SymbolArray:
   EnforcedStyle: percent
   MinSize: 0


### PR DESCRIPTION
disables
```
Style/StructInheritance: Don't extend an instance initialized by Struct.new. (https://github.com/rubocop-hq/ruby-style-guide#no-extend-struct-new)
```