### PR TITLE
disable checking ClassAndModuleChildren as it was disabled in old config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3131,7 +3131,7 @@ Style/ClassAndModuleChildren:
   # have the knowledge to perform either operation safely and thus requires
   # manual oversight.
   SafeAutoCorrect: false
-  Enabled: true
+  Enabled: false
   VersionAdded: '0.19'
   #
   # Basically there are two different styles:


### PR DESCRIPTION
## This PR does the following:
<!-- List what is being added/removed by your PR. Include screenshots/GIFs as appropriate. -->

-

### Notes to Reviewers:
<!-- Tell reviewers if there is a recommended order for reading the code or if there are particular things you would like feedback on. -->

### Notes to Merger:
- Make a new version tag for the latest version.
- Delegate updating linter configuration to respective members of _all_ Fractured Atlas applications that point to the linter[s] you've updated.

This is important because these applications may be locked to a specific version and will not automatically pick up new changes and improvements.
